### PR TITLE
Found some conflict markers at settings file.

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -133,14 +133,10 @@ INSTALLED_APPS = [
     "account",
     "metron",
     "pinax.eventlog",
-<<<<<<< HEAD
     "easy_thumbnails",
     "kaleo",
     "teams",
-    "wiki",
-=======
     "pinax.wiki",
->>>>>>> wiki
 
     # project
     "{{ project_name }}",
@@ -180,15 +176,11 @@ FIXTURE_DIRS = [
     os.path.join(PROJECT_ROOT, "fixtures"),
 ]
 
-<<<<<<< HEAD
-WIKI_HOOKSET = "{{ project_name }}.hooks.ProjectWikiHookset"
-WIKI_BINDERS = [
+PINAX_WIKI_HOOKSET = "{{ project_name }}.hooks.ProjectWikiHookset"
+PINAX_WIKI_BINDERS = [
     "{{ project_name }}.binders.UserBinder",
     "{{ project_name }}.binders.TeamBinder"
 ]
-=======
-PINAX_WIKI_HOOKSET = "{{ project_name }}.hooks.ProjectWikiHookset"
->>>>>>> wiki
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 ACCOUNT_OPEN_SIGNUP = True


### PR DESCRIPTION
With removing git conflict markers at settings file, I assumed that `WIKI_*` notations changed to `PINAX_WIKI_*` due to https://github.com/pinax/pinax-wiki.
Migration tested, but actually I found some more bugs in this `team-wiki` branch. Will keep working on it.