### PR TITLE
Use static templatetag to remove hardcoded paths

### DIFF
--- a/project_name/templates/_scripts.html
+++ b/project_name/templates/_scripts.html
@@ -1,1 +1,2 @@
-<script src='/site_media/static/js/site-5e73bbeeb0.js'></script>
+{% load staticfiles %}
+<script src='{% static "js/site-5e73bbeeb0.js" %}'></script>

--- a/project_name/templates/_styles.html
+++ b/project_name/templates/_styles.html
@@ -1,1 +1,2 @@
-<link href='/site_media/static/css/site-9713c11499.css' rel='stylesheet' />
+{% load staticfiles %}
+<link href='{% static "css/site-9713c11499.css" %}' rel='stylesheet' />


### PR DESCRIPTION
These hardcoded paths cause issues.  For example, if I want to host the
site at a different root path instead of '/', I have to edit these.

I think I branched from the correct branch(`zero`).  If I understand correctly, you are keeping all the base code for all the starter project on `zero`. 